### PR TITLE
Invoke shell script using `system()` not `exec()`

### DIFF
--- a/exe/ship-it
+++ b/exe/ship-it
@@ -3,4 +3,4 @@
 bin_dir = File.expand_path('../bin', File.dirname(__FILE__))
 shell_script_path = File.join(bin_dir, 'ship-it.sh')
 
-exec shell_script_path, *ARGV
+system shell_script_path, *ARGV

--- a/exe/unship-it
+++ b/exe/unship-it
@@ -3,4 +3,4 @@
 bin_dir = File.expand_path('../bin', File.dirname(__FILE__))
 shell_script_path = File.join(bin_dir, 'unship-it.sh')
 
-exec shell_script_path, *ARGV
+system shell_script_path, *ARGV

--- a/exe/unstage-last
+++ b/exe/unstage-last
@@ -3,4 +3,4 @@
 bin_dir = File.expand_path('../bin', File.dirname(__FILE__))
 shell_script_path = File.join(bin_dir, 'unstage-last.sh')
 
-exec shell_script_path, *ARGV
+system shell_script_path, *ARGV


### PR DESCRIPTION
Using `exec()` causes the current process to be replaced, which causes the caller of ship-it to die unexpectedly.

This was never an issue before because our clients always loaded ship-it as the last thing they did.  However, sapi recently added an `ensure` block after loading ship-it, and that `ensure` block silently failed to run due to the exec.