### PR TITLE
Check remote branch exists before resolving conflicts with it

### DIFF
--- a/lib/ship_it/git_actions.rb
+++ b/lib/ship_it/git_actions.rb
@@ -165,6 +165,10 @@ class GitActions
     "#{ref}/*"
   end
 
+  def remote_branches_list
+    git(['branch', '--list', '--format=%(refname:short)', "--remote"]).split("\n")
+  end
+
   def query_rev_name(revision)
     is_remote = revision.start_with?("#{@remote}/")
     _status, newrev = git(%W"name-rev --name-only --refs #{search_ref(is_remote)} --no-undefined #{revision}", forward_failure: true)

--- a/lib/ship_it/merge_helpers.rb
+++ b/lib/ship_it/merge_helpers.rb
@@ -247,5 +247,11 @@ class MergeHelpers
 
   def load_branches
     @branches = @git.current_branch_list.map {|branch_data| Branch.new(*branch_data)}
+    gone_branches = @branches.select do |branch|
+      @logger.info "Checking #{branch.name}"
+      !@git.query_rev_name("#{@git.remote}/#{branch.name}")
+    end
+    @branches -= gone_branches
+    @logger.info "Disappeared: #{gone_branches.map(&:name)}"
   end
 end

--- a/lib/ship_it/merge_helpers.rb
+++ b/lib/ship_it/merge_helpers.rb
@@ -247,9 +247,10 @@ class MergeHelpers
 
   def load_branches
     @branches = @git.current_branch_list.map {|branch_data| Branch.new(*branch_data)}
+    remote_branches_list = @git.remote_branches_list
     gone_branches = @branches.select do |branch|
       @logger.info "Checking #{branch.name}"
-      !@git.query_rev_name("#{@git.remote}/#{branch.name}")
+      !remote_branches_list.include?("#{@git.remote}/#{branch.name}")
     end
     @branches -= gone_branches
     @logger.info "Disappeared: #{gone_branches.map(&:name)}"

--- a/lib/ship_it/rebuild_staging.rb
+++ b/lib/ship_it/rebuild_staging.rb
@@ -82,12 +82,6 @@ class RebuildStaging < MergeHelpers
       @git.branch_in?(branch.commit_id, "#{@git.remote}/master")
     end
     @logger.debug "In master: #{@branches_in_master.map(&:name)}"
-    gone_branches = @branches.select do |branch|
-      @logger.info "Checking #{branch.name}"
-      !@git.query_rev_name("#{@git.remote}/#{branch.name}")
-    end
-    @branches -= gone_branches
-    @logger.info "Disappeared: #{gone_branches.map(&:name)}"
     @failed_report = {}
   end
 

--- a/test/lib/rebuild-staging_test.rb
+++ b/test/lib/rebuild-staging_test.rb
@@ -352,6 +352,7 @@ class RebuildStagingTest < RepoTest
     assert rebuild(delayed_conflict_drop: true), -> { @log.string }
     refute File.exist?('failed_report.json')
     assert_equal [new_branch.name], @git.current_branch_list.map(&:first), @log.string
+    assert_includes @log.string, "Disappeared: [\"#{branch_data[1].name}\"]", @log.string
   end
 
   def test_leaves_unrelated_conflicts_alone

--- a/test/lib/resolve-merge_test.rb
+++ b/test/lib/resolve-merge_test.rb
@@ -245,6 +245,21 @@ class ResolveMergeTest < RepoTest
     assert_equal new_branch.log, new_branch_list[1], new_branch_list.inspect + "\n" + @log.string
   end
 
+  def test_gone_branches
+    build_staging 2
+    deleted_branch = @branches.values.first
+    new_branch = add_branch(fname: default_branch_file(deleted_branch))
+    @git.drop_remote deleted_branch.name
+
+    flush_log
+    resolve_merge_without_user_request(new_branch.name)
+
+    new_branch_list = BranchList.read('new_branches.list')
+    assert_equal [new_branch.log], new_branch_list, new_branch_list.inspect + "\n" + @log.string
+    refute_includes new_branch_list.map(&:first), deleted_branch.name, @log.string
+    assert_includes @log.string, "Disappeared: [\"#{deleted_branch.name}\"]", @log.string
+  end
+
   def replace_branch(branch, branch_with_new_data)
     branch2_name = branch_with_new_data.name
     if !@git.query_rev_name(branch2_name)


### PR DESCRIPTION
The “cosmetic” commit exists because I initially wrote a different test for the same functionality in `RebuildStaging`, but then I saw the more comprehensive existing test, so I incorporated the one extra assertion to match the test in the new commit.